### PR TITLE
Make parseString non-IO

### DIFF
--- a/src/Parser/ImplParsec.hs
+++ b/src/Parser/ImplParsec.hs
@@ -30,8 +30,8 @@ parseFile fname
          return (parse parseRemarks fname input)
 
 -- |Parse a Remarks Judgement from a string
-parseString :: String -> IO (Either ParseError [Judgement])
-parseString input = return $ parse parseRemarks "String" input
+parseString :: String -> Either ParseError [Judgement]
+parseString input = parse parseRemarks "String" input
 
 -------------------------------------------------------------------------------
 -- * Implementation of the parser


### PR DESCRIPTION
I see no reason for it to be an IO action.