### PR TITLE
Optionally show points when generating feedback

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -202,10 +202,10 @@ export_pdfMark js = do
     -- Right newJs -> putStrLn $ show newJs
     Left e -> report $ reportInvalid e
 
-export_feedback :: [Judgement] -> IO ()
-export_feedback js = do
+export_feedback :: FeedbackOpts -> [Judgement] -> IO ()
+export_feedback opts js = do
   case (mapM interpProps js) of
-    Right newJs -> putStrLn $ exportFeedback newJs
+    Right newJs -> putStrLn $ exportFeedback opts newJs
     -- Right newJs -> putStrLn $ show newJs
     Left e -> report $ reportInvalid e
 
@@ -244,8 +244,12 @@ main = do
     [] -> noCommand
     ("parse" : paths) ->
       with paths $ putStrLn . pretty
+    ("feedback" : "--with-points" : paths) ->
+      with paths $ mapM_ (export_feedback $
+        FeedbackOpts { withPoints = True })
     ("feedback" : paths) ->
-      with paths $ mapM_ export_feedback
+      with paths $ mapM_ (export_feedback $
+        FeedbackOpts { withPoints = False })
     ("check" : paths) ->
       with paths $ mapM_ check
     ("valid" : paths) ->

--- a/src/Export.hs
+++ b/src/Export.hs
@@ -1,4 +1,4 @@
-module Export (exportFeedback, exportHTML, exportCSV, exportHTMLTable, exportResultsTable, exportMD, unify, summary, exportPdfMark) where
+module Export (FeedbackOpts(..), exportFeedback, exportHTML, exportCSV, exportHTMLTable, exportResultsTable, exportMD, unify, summary, exportPdfMark) where
 
 import Ast
 import Invalid
@@ -25,8 +25,8 @@ exportHTMLTable js = toHTML $ transp $ htmlTableRemarks js
 exportMD :: [Judgement] -> String
 exportMD js = mdRemarks js
 
-exportFeedback :: [Judgement] -> String
-exportFeedback js = feedbackRemarks js
+exportFeedback :: FeedbackOpts -> [Judgement] -> String
+exportFeedback opts js = feedbackRemarks opts js
 
 exportResultsTable :: [Judgement] -> String
 exportResultsTable js = toCSV ";" $ transp $ resultsTableRemarks js


### PR DESCRIPTION
Use the option --with-points to show them.

The feedback command still has the perhaps awkward behaviour that it produces nothing for judgements without a feedback sub-judgement, but I think that might well be called a feature.

I suspect the idea of the feedback command is to generate feedback that is more student-friendly than bare points and teacher comments might be. I like that. If not, someone let me know :-)

I find this related to #28 