### PR TITLE
Bug-fix: break line break after feedback text

### DIFF
--- a/src/Export/Feedback.hs
+++ b/src/Export/Feedback.hs
@@ -15,13 +15,16 @@ feedbackRemarks :: FeedbackOpts -> [Judgement] -> String
 feedbackRemarks opts = render . vcat . map (formatJudgement opts 1)
 
 formatJudgement :: FeedbackOpts -> Int -> Judgement -> Doc
-formatJudgement _ _ (Feedback (_, t)) = text t
+formatJudgement _ _ (Feedback (_, t)) =
+  case length t of
+    0 -> empty
+    _ -> text t $+$ text ""
 formatJudgement _ _ (Bonus (_, _, _)) = empty
 formatJudgement opts depth (j @ (Judgement (_, _, _, judgements))) =
   case isEmpty subj of
     True -> empty
     False -> formatHeader (withPoints opts) depth j
-              $+$ text "" $+$ subj $+$ text ""
+              $+$ text "" $+$ subj
   where
     subj = vcat $ map (formatJudgement opts (depth + 1)) judgements
 


### PR DESCRIPTION
Not after sub-judgements; those will take care of themselves.