### PR TITLE
Allow missing line break at eof

### DIFF
--- a/src/Parser/ImplParsec.hs
+++ b/src/Parser/ImplParsec.hs
@@ -37,14 +37,14 @@ parseString input = parse parseRemarks "String" input
 -- * Implementation of the parser
 -------------------------------------------------------------------------------
 
+endline :: MrkParser ()
+endline = choice [void $ many1 newline, eof]
+
 parseLine :: MrkParser String
-parseLine = manyTill anyChar (many1 newline)
+parseLine = manyTill anyChar endline
 
 parseIndentation :: MrkParser ()
 parseIndentation = string indentation >> pure ()
-
-endline :: MrkParser ()
-endline = void $ many1 newline
 
 -- string :: String -> MrkParser ()
 -- string s = sequence_ $ mapM char s
@@ -105,14 +105,14 @@ parseBonus _ = do
   void $ char '+'
   total <- parsePointsNum
   endline
-  properties <- sepEndBy parseProperty newline
+  properties <- sepEndBy parseProperty endline
   comments <- many $ parseComment 1
   pure $ Bonus (total, properties, comments)
 
 parseFeedback :: Int -> MrkParser Judgement
 parseFeedback depth = do
   endline
-  properties <- sepEndBy parseProperty newline
+  properties <- sepEndBy parseProperty endline
   text <- manyTill anyChar $ try (lookAhead (parseJudgement depth))
   pure $ Feedback (properties, text)
   -- where
@@ -224,7 +224,7 @@ parsePropertyExp = choice [try funProp, try lookupPropChild, try lookupPropParen
       pure (s:ss)
     listH2 = do
       -- spaces
-      s <- manyTill anyChar $ char '\n'
+      s <- manyTill anyChar $ endline
       pure [s]
     nolineBreak = do
       c <- lookAhead anyChar

--- a/test/Parser/BlackBoxTests.hs
+++ b/test/Parser/BlackBoxTests.hs
@@ -19,14 +19,32 @@ unitTests = testGroup "Unit tests"
         Right
           [ Judgement (Header ("A",Given 0,0), [], [], [])
           ]
+  , testCase "Lone header line (no line break at eof)" $
+      parseString "# A: 0/0" @?=
+        Right
+          [ Judgement (Header ("A",Given 0,0), [], [], [])
+          ]
   , testCase "A couple same-depth header lines" $
       parseString "# A: 0/0\n# B: 0/0\n" @?=
         Right
           [ Judgement (Header ("A",Given 0,0), [], [], [])
           , Judgement (Header ("B",Given 0,0), [], [], [])
           ]
+  , testCase "A couple same-depth header lines (no line break at eof)" $
+      parseString "# A: 0/0\n# B: 0/0" @?=
+        Right
+          [ Judgement (Header ("A",Given 0,0), [], [], [])
+          , Judgement (Header ("B",Given 0,0), [], [], [])
+          ]
   , testCase "A simple hierarchy of headers" $
       parseString "# A: 0/0\n## B: 0/0\n" @?=
+        Right
+          [ Judgement (Header ("A",Given 0,0), [], [],
+            [ Judgement (Header ("B",Given 0,0), [], [], [])
+            ])
+          ]
+  , testCase "A simple hierarchy of headers (no line break at eof)" $
+      parseString "# A: 0/0\n## B: 0/0" @?=
         Right
           [ Judgement (Header ("A",Given 0,0), [], [],
             [ Judgement (Header ("B",Given 0,0), [], [], [])
@@ -39,6 +57,37 @@ unitTests = testGroup "Unit tests"
             [ Judgement (Header ("B",Given 0,0), [], [], [])
             ])
           , Judgement (Header ("C",Given 0,0), [], [], [])
+          ]
+  , testCase "Simple bonus" $
+      parseString "# Bonus: +5\n" @?=
+        Right [Bonus (500, [], [])]
+  , testCase "Simple bonus (no line break at eof)" $
+      parseString "# Bonus: +5" @?=
+        Right [Bonus (500, [], [])]
+  , testCase "Bonus with props" $
+      parseString "# Bonus: +5\n  :x:y\n" @?=
+        Right [Bonus (500,[Property ("x",Value "y")],[])]
+  , testCase "Bonus with props (no line break at eof)" $
+      parseString "# Bonus: +5\n  :x:y" @?=
+        Right [Bonus (500,[Property ("x",Value "y")],[])]
+  , testCase "Judgement with comments (no line break at eof)" $
+      parseString "# A: 5/10\n  - Bad indentation\n    I'd say" @?=
+        Right
+          [
+            Judgement (Header ("A",Given 500,1000),[],[
+              Comment (Negative,[
+                CommentStr "Bad indentation",
+                CommentStr "I'd say"
+              ])],[])
+          ]
+  , testCase "Another judgement with comments (no line break at eof)" $
+      parseString "# A: 5/10\n  - Bad indentation\n  + Otherwise, OK" @?=
+        Right
+          [
+            Judgement (Header ("A",Given 500,1000),[],[
+              Comment (Negative,[CommentStr "Bad indentation"]),
+              Comment (Positive,[CommentStr "Otherwise, OK"])
+            ],[])
           ]
   ]
 


### PR DESCRIPTION
Related to #36 

P.S. Should we also just purge the ReadP parser?