### PR TITLE
Make nix-build work on darwin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 # This default.nix produces a statically linked executable with no
-# library dependencies.
+# library dependencies on linux.
 let pkgs = import <nixpkgs> {};
 in pkgs.haskell.lib.overrideCabal
   (pkgs.haskell.packages.ghc910.callCabal2nix "remarks" ./. {})
@@ -8,22 +8,23 @@ in pkgs.haskell.lib.overrideCabal
     isExecutable = true;
     enableSharedExecutables = false;
     enableSharedLibraries = false;
-    configureFlags = [
-      "--ghc-option=-split-sections"
-      "--ghc-option=-optl=-static"
-      "--ghc-option=-optl=-lbz2"
-      "--ghc-option=-optl=-lz"
-      "--ghc-option=-optl=-lelf"
-      "--ghc-option=-optl=-llzma"
-      "--ghc-option=-optl=-lzstd"
-      "--extra-lib-dirs=${pkgs.glibc.static}/lib"
-      "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"
-      "--extra-lib-dirs=${pkgs.zlib.static}/lib"
-      "--extra-lib-dirs=${(pkgs.xz.override { enableStatic = true; }).out}/lib"
-      "--extra-lib-dirs=${(pkgs.zstd.override { enableStatic = true; }).out}/lib"
-      "--extra-lib-dirs=${(pkgs.bzip2.override { enableStatic = true; }).out}/lib"
-      "--extra-lib-dirs=${(pkgs.elfutils.overrideAttrs (old: { dontDisableStatic = true; })).out}/lib"
-      "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
-    ];
+    configureFlags =
+      [ "--ghc-option=-split-sections" ]
+      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+        "--ghc-option=-optl=-static"
+        "--ghc-option=-optl=-lbz2"
+        "--ghc-option=-optl=-lz"
+        "--ghc-option=-optl=-lelf"
+        "--ghc-option=-optl=-llzma"
+        "--ghc-option=-optl=-lzstd"
+        "--extra-lib-dirs=${pkgs.glibc.static}/lib"
+        "--extra-lib-dirs=${pkgs.gmp6.override { withStatic = true; }}/lib"
+        "--extra-lib-dirs=${pkgs.zlib.static}/lib"
+        "--extra-lib-dirs=${(pkgs.xz.override { enableStatic = true; }).out}/lib"
+        "--extra-lib-dirs=${(pkgs.zstd.override { enableStatic = true; }).out}/lib"
+        "--extra-lib-dirs=${(pkgs.bzip2.override { enableStatic = true; }).out}/lib"
+        "--extra-lib-dirs=${(pkgs.elfutils.overrideAttrs (old: { dontDisableStatic = true; })).out}/lib"
+        "--extra-lib-dirs=${pkgs.libffi.overrideAttrs (old: { dontDisableStatic = true; })}/lib"
+      ];
   }
   )


### PR DESCRIPTION
I was happy to  find a `default.nix`!

The static linking does not work on macOS (darwin). By making the static options only apply to linux, running `nix-build` works on macOS as well. Because I run macOS, I have not verified that the change doesn't break linux builds. Please verify this before you consider accepting the request.